### PR TITLE
Remove console.log

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -52,8 +52,7 @@ exports.aceDomLineProcessLineAttributes = function(name, context){
   if (lineHeightsType){
     tagIndex = _.indexOf(lineHeights, lineHeightsType[1]);
   }
-
-  console.log(lineHeights);      
+    
   if (tagIndex !== undefined && tagIndex >= 0){
     var tag = lineHeights[tagIndex]; 
     if(tag == "1") var height = "130%";


### PR DESCRIPTION
Remove console.log that pollutes the browser console, because it's inside a function that gets called quite often. It was probably used for debugging purposes in development and is no longer necessary.
